### PR TITLE
fix(deploy): correct build command in wrangler.toml

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -4,8 +4,7 @@ compatibility_date = "2024-08-15"
 
 # Build and output configuration
 [build]
-command = "npm install"
-command = "npm run build"
+command = "npm install && npm run build"
 publish = "dist"
 
 # Environment variables for production


### PR DESCRIPTION
The Cloudflare Pages deployment was failing with a white screen because the `wrangler.toml` file had a duplicated `command` key in the `[build]` section. This caused the `npm install` command to be skipped, leading to an incomplete build.

This change combines the `npm install` and `npm run build` commands into a single line to ensure dependencies are installed before the build process runs, resolving the deployment issue.